### PR TITLE
Rename teardown, remove finished and position method inside the class def

### DIFF
--- a/lib/logstash/outputs/jms.rb
+++ b/lib/logstash/outputs/jms.rb
@@ -117,11 +117,10 @@ config :jndi_context, :validate => :hash
                      :backtrace => e.backtrace)
       end
   end # def receive
-end # class LogStash::Output::Jms
 
-def teardown
-  @producer.close()
-  @session.close()
-  @connection.close()
-  finished
-end
+  def close
+    @producer.close()
+    @session.close()
+    @connection.close()
+  end
+end # class LogStash::Output::Jms


### PR DESCRIPTION
Yikes!! Check out where the original teardown method was defined!
