### PR TITLE
Change password config type to password to prevent from leaks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.5
+  - Change `password` config type to `password` to prevent leaking in the debug logs [#15](https://github.com/logstash-plugins/logstash-output-jms/pull/15) 
+
 ## 3.0.4
   - Fixes an issue where `delivery_mode` directive was silently ignored.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -52,7 +52,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-factory>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-jndi_context>> |<<hash,hash>>|No
 | <<plugins-{type}s-{plugin}-jndi_name>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-password>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-pub_sub>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-require_jars>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-username>> |<<string,string>>|No
@@ -119,7 +119,7 @@ Name of JNDI entry at which the Factory can be found
 [id="plugins-{type}s-{plugin}-password"]
 ===== `password` 
 
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 Password to use when connecting to the JMS provider

--- a/lib/logstash/outputs/jms.rb
+++ b/lib/logstash/outputs/jms.rb
@@ -51,7 +51,7 @@ config :factory, :validate => :string
 # Username to connect to JMS provider with
 config :username, :validate => :string
 # Password to use when connecting to the JMS provider
-config :password, :validate => :string
+config :password, :validate => :password
 # Url to use when connecting to the JMS provider
 config :broker_url, :validate => :string
 
@@ -88,7 +88,7 @@ config :jndi_context, :validate => :hash
         :require_jars => @require_jars,
         :factory => @factory,
         :username => @username,
-        :password => @password,
+        :password => @password.nil? ? nil : @password.value,
         :broker_url => @broker_url,
         :url => @broker_url # "broker_url" is named "url" with Oracle AQ
         }

--- a/logstash-output-jms.gemspec
+++ b/logstash-output-jms.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
 	s.name            = 'logstash-output-jms'
-	s.version         = '3.0.4'
+	s.version         = '3.0.5'
 	s.licenses        = ['Apache License (2.0)']
 	s.summary         = "Push events to a JMS topic or queue."
 	s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/jms_spec.rb
+++ b/spec/outputs/jms_spec.rb
@@ -34,4 +34,14 @@ describe "outputs/jms" do
       # Add code to check the message is correct on the queue.
     end
   end
+
+  describe "debugging `password`" do
+    let(:config) { jms_config.merge("password" => "$ecre&-key") }
+    it "should not show origin value" do
+
+      output = LogStash::Plugin.lookup("output", "jms").new(config)
+      expect(output.logger).to receive(:debug).with('<password>')
+      output.logger.send(:debug, output.password.to_s)
+    end
+  end
 end


### PR DESCRIPTION
When using `--config.debug` option when running Logstash, `password` config may be seen in the logs.
This PR changes the `password` config type in order to prevent from leaking it in the debug logs.

- Closes https://github.com/logstash-plugins/logstash-output-jms/issues/14